### PR TITLE
Facilitate batch lhm

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,2 @@
+c
+table_read(:small_table).columns["id"]

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,2 +1,0 @@
-c
-table_read(:small_table).columns["id"]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 gemfiles/*.lock
 pkg/*
 .rvmrc
+.byebug_history

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -67,6 +67,14 @@ module Lhm
       @throttle / 1000.0
     end
 
+    def select_query(offset, columns_to_be_selected = nil)
+      columns_to_be_selected ||= columns
+      "select #{ columns_to_be_selected } from `#{ origin_name }` " +
+        "where `#{origin_primary_key}` > #{offset} " +
+        "and `#{origin_primary_key}` <= #{@limit} " +
+        "order by #{origin_primary_key} asc limit #{@stride}"
+    end
+
   private
 
     def destination_name
@@ -133,13 +141,6 @@ module Lhm
       print "\n"
     rescue => e
       debugger # TODO Remove this
-    end
-
-    def select_query(offset, columns_to_be_selected = nil)
-      columns_to_be_selected ||= columns
-      "select #{ columns_to_be_selected } from `#{ origin_name }` " +
-        "where `#{origin_primary_key}` > #{offset} " +
-        "order by #{origin_primary_key} asc limit #{@stride}"
     end
   end
 end

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -20,7 +20,7 @@ module Lhm
       @throttle = options[:throttle] || 100
       @start = options[:start] || select_start
       @limit = options[:limit] || select_limit
-      @legacy_mode = options[:legacy_mode] || false
+      @batch_mode = options[:batch_mode] || false
     end
 
     # Copies chunks of size `stride`, starting from `start` up to id `limit`.
@@ -94,10 +94,10 @@ module Lhm
 
     def execute
       up_to do |lowest, highest|
-        affected_rows = if @legacy_mode
-          @connection.update(copy(lowest, highest))
-        else
+        affected_rows = if @batch_mode
           @connection.update(copy_batchwise(lowest, @stride))
+        else
+          @connection.update(copy(lowest, highest))
         end
         
 

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -101,12 +101,13 @@ module Lhm
       while records.any?
         records_size = @connection.update(copy_batchwise(select_query(start_value)))
         break if records_size.zero?
-        start_value = @connection.select_last(select_query(start_value))["#{origin_primary_key}"]
+        start_value = @connection.select_last(select_query(start_value, origin_primary_key))["#{origin_primary_key}"]
       end
     end
 
-    def select_query(offset)
-      "select #{ columns } from `#{ origin_name }` where `#{origin_primary_key}` > #{offset} order by #{origin_primary_key} asc limit #{@stride}"
+    def select_query(offset, columns_to_be_selected = nil)
+      columns_to_be_selected ||= columns
+      "select #{ columns_to_be_selected } from `#{ origin_name }` where `#{origin_primary_key}` > #{offset} order by #{origin_primary_key} asc limit #{@stride}"
     end
 
     def execute_legacy_mode

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -116,6 +116,10 @@ module Lhm
         @adapter.select_one(sql)
       end
 
+      def select_last(sql)
+        select_all(sql).last
+      end
+
       def select_values(sql)
         @adapter.select_values(sql)
       end

--- a/spec/fixtures/batch_destination.ddl
+++ b/spec/fixtures/batch_destination.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `batch_destination` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `destination` int(11) DEFAULT NULL,
+  `common` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/batch_origin.ddl
+++ b/spec/fixtures/batch_origin.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `batch_origin` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `origin` int(11) DEFAULT NULL,
+  `common` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -40,7 +40,7 @@ describe Lhm::Chunker do
     it "should copy 100 rows from batch_origin to batch_destination" do
       100.times { |n| execute("insert into batch_origin set id = '#{ n * n + 100 }'") }
 
-      Lhm::Chunker.new(@batch_migration, connection, { :stride => 50, :batch_mode => true }).run
+      Lhm::Chunker.new(@batch_migration, connection, { :stride => 40, :batch_mode => true }).run
 
       slave do
         count_all(@batch_destination.name).must_equal(100)

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -29,4 +29,22 @@ describe Lhm::Chunker do
       end
     end
   end
+
+  describe "Batch copy test" do
+    before(:each) do
+      @batch_origin = table_create(:batch_origin)
+      @batch_destination = table_create(:batch_destination)
+      @batch_migration = Lhm::Migration.new(@batch_origin, @batch_destination)
+    end
+
+    it "should copy 100 rows from batch_origin to batch_destination" do
+      100.times { |n| execute("insert into batch_origin set id = '#{ n * n + 100 }'") }
+
+      Lhm::Chunker.new(@batch_migration, connection, { :stride => 50, :batch_mode => true }).run
+
+      slave do
+        count_all(@batch_destination.name).must_equal(100)
+      end
+    end
+  end
 end

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -139,22 +139,6 @@ describe Lhm do
       end
     end
 
-    it "should change the last column in a table" do
-      table_create(:small_table)
-
-      Lhm.change_table(:small_table, :atomic_switch => false) do |t|
-        t.change_column(:id, "int(5)")
-      end
-
-      slave do
-        table_read(:small_table).columns["id"].must_equal({
-          :type => "int(5)",
-          :is_nullable => "NO",
-          :column_default => "0"
-        })
-      end
-    end
-
     describe "parallel" do
       it "should perserve inserts during migration" do
         50.times { |n| execute("insert into users set reference = '#{ n }'") }

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -39,10 +39,11 @@ describe Lhm::Chunker do
     end
 
     it "should copy the correct range and column" do
-      @chunker.copy_batchwise(from = 1, batch = 100).must_equal(
+      @chunker.copy_batchwise(@chunker.select_query(from = 1)).must_equal(
         "insert ignore into `destination` (`secret`) " +
         "select `secret` from `origin` " +
-        "where `id` >= #{from} order by id asc limit #{batch}"
+        "where `id` > #{from} and `id` <= 10 " +
+        "order by id asc limit 40000"
       )
     end
   end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -25,10 +25,5 @@ describe Lhm::Table do
       @table = Lhm::Table.new("table", "uuid")
       @table.satisfies_primary_key?.must_equal false
     end
-
-    it "should not be satisfied with multicolumn primary key" do
-      @table = Lhm::Table.new("table", ["id", "secondary"])
-      @table.satisfies_primary_key?.must_equal false
-    end
   end
 end


### PR DESCRIPTION
Description::
Normally lhm takes min and max id of a table and migrates records in batches between min and max. We have some shards having too much of difference between min and max ids(some in billions). So it takes days to run migrations. This change is to take records by primary key in batches so that migration is fast.
PS: Used legacy_mode to switch back to older way by passing param. Default is new way.