### PR TITLE
INC-2160 - LHM execute batch Issue Fix

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -139,8 +139,6 @@ module Lhm
         print '.'
       end
       print "\n"
-    rescue => e
-      puts e.message
     end
   end
 end


### PR DESCRIPTION
Description 

- When Lhm Copy table is running and if incase in between the process in mysql is killed/aborted either manually or unknowingly , MySQL is throwing Connection Lost Exception. On that case we must propagate that exception to parent method . Rescuing Exception would lead to partial copied table to be renamed


Before fix (Exception rescued and table rename) :

<img width="1428" alt="Screenshot 2023-03-12 at 4 21 28 PM" src="https://user-images.githubusercontent.com/87070837/224539920-841f5719-1461-46cb-aeda-cd5cb1ef2342.png">


Post fix (Exception thrown and table not renamed , therefore dropping the lhm partial copied table ) :

<img width="1575" alt="Screenshot 2023-03-12 at 4 22 50 PM" src="https://user-images.githubusercontent.com/87070837/224540055-d690f39b-5a7c-4fc4-bc14-afbe2bc7de93.png">


