### PR TITLE
[FD-149680] Retain triggers by default fix

### DIFF
--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -151,14 +151,6 @@ module Lhm
              and trigger_name like '#{trigger_name}%'
         })
       end
-
-      def trigger_exists_in_db?(trigger_name)
-        !!select_one(%Q{
-          select trigger_name
-            from information_schema.triggers
-           where trigger_name like '#{trigger_name}%'
-        })
-      end
     end
   end
 end

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -151,6 +151,14 @@ module Lhm
              and trigger_name like '#{trigger_name}%'
         })
       end
+
+      def trigger_exists_in_db?(trigger_name)
+        !!select_one(%Q{
+          select trigger_name
+            from information_schema.triggers
+           where trigger_name like '#{trigger_name}%'
+        })
+      end
     end
   end
 end

--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -148,7 +148,7 @@ module Lhm
           select trigger_name
             from information_schema.triggers
            where event_object_table='#{table_name}'
-             and trigger_name like '#{trigger_name}'
+             and trigger_name like '#{trigger_name}%'
         })
       end
     end

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -38,13 +38,14 @@ module Lhm
 
       migration = @migrator.run
 
+      retain_triggers = options.fetch(:retain_triggers, true)
       Entangler.new(migration, @connection).run do
         Chunker.new(migration, @connection, options).run
         if options[:atomic_switch]
           AtomicSwitcher.new(migration, @connection).run
-          TriggerSwitcher.new.copy_triggers(@origin, migration.archive_name, @connection) unless @origin.triggers.count.zero?
+          TriggerSwitcher.new.copy_triggers(@origin, migration.archive_name, @connection) if retain_triggers
         else
-          LockedSwitcher.new(migration, @connection).run
+          LockedSwitcher.new(migration, @connection, retain_triggers).run
         end
       end
     end

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -42,9 +42,9 @@ module Lhm
         Chunker.new(migration, @connection, options).run
         if options[:atomic_switch]
           AtomicSwitcher.new(migration, @connection).run
-          TriggerSwitcher.new.copy_triggers(@origin, migration.archive_name, @connection) if options[:retain_triggers]
+          TriggerSwitcher.new.copy_triggers(@origin, migration.archive_name, @connection) unless @origin.triggers.count.zero?
         else
-          LockedSwitcher.new(migration, @connection, options[:retain_triggers]).run
+          LockedSwitcher.new(migration, @connection).run
         end
       end
     end

--- a/lib/lhm/locked_switcher.rb
+++ b/lib/lhm/locked_switcher.rb
@@ -23,12 +23,11 @@ module Lhm
 
     attr_reader :connection
 
-    def initialize(migration, connection = nil, retain_triggers = false)
+    def initialize(migration, connection = nil)
       @migration = migration
       @connection = connection
       @origin = migration.origin
       @destination = migration.destination
-      @retain_triggers = retain_triggers
     end
 
     def statements
@@ -43,7 +42,7 @@ module Lhm
         "commit",
         "unlock tables"
       ]
-      if @retain_triggers
+      unless @origin.triggers.count.zero?
         trigger_copy_queries = []
         trigger_copy_queries << "lock table `#{ @migration.archive_name }` write, `#{ @origin.name }` write"
         @origin.triggers.each do |trigger|

--- a/lib/lhm/locked_switcher.rb
+++ b/lib/lhm/locked_switcher.rb
@@ -23,11 +23,12 @@ module Lhm
 
     attr_reader :connection
 
-    def initialize(migration, connection = nil)
+    def initialize(migration, connection = nil, retain_triggers = true)
       @migration = migration
       @connection = connection
       @origin = migration.origin
       @destination = migration.destination
+      @retain_triggers = retain_triggers
     end
 
     def statements
@@ -42,7 +43,7 @@ module Lhm
         "commit",
         "unlock tables"
       ]
-      unless @origin.triggers.count.zero?
+      if @retain_triggers
         trigger_copy_queries = []
         trigger_copy_queries << "lock table `#{ @migration.archive_name }` write, `#{ @origin.name }` write"
         @origin.triggers.each do |trigger|

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -131,7 +131,7 @@ module IntegrationHelper
   def check_and_create_trigger_on_users_table
     table_name = 'users'
     trigger_name = 'timestamp_trigger'
-    execute "DROP TRIGGER #{trigger_name}" if connection.trigger_exists_in_db?(trigger_name)
+    execute "DROP TRIGGER #{trigger_name}" if trigger_exists?(table_name, trigger_name)
 
     query = "CREATE TRIGGER #{trigger_name} BEFORE INSERT ON #{table_name} FOR EACH ROW
            BEGIN

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -131,13 +131,13 @@ module IntegrationHelper
   def check_and_create_trigger_on_users_table
     table_name = 'users'
     trigger_name = 'timestamp_trigger'
-    unless trigger_exists?(table_name, trigger_name)
-      query = "CREATE TRIGGER #{trigger_name} BEFORE INSERT ON #{table_name} FOR EACH ROW
-             BEGIN
-              SET NEW.created_at = NOW();
-             END;"
-      execute query
-    end
+    execute "DROP TRIGGER #{trigger_name}" if connection.trigger_exists_in_db?(trigger_name)
+
+    query = "CREATE TRIGGER #{trigger_name} BEFORE INSERT ON #{table_name} FOR EACH ROW
+           BEGIN
+            SET NEW.created_at = NOW();
+           END;"
+    execute query
   end
 
   #

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -29,11 +29,11 @@ describe Lhm do
       end
     end
 
-    it "should retain triggers while migration if retain_triggers is set to true in atomic switch" do
+    it "should retain triggers while migration in atomic switch" do
       table_name = 'users'
       trigger_name = 'timestamp_trigger'
       check_and_create_trigger_on_users_table
-      Lhm.change_table(table_name.to_sym, :atomic_switch => true, :cleanup => true, :retain_triggers => true) do |t|
+      Lhm.change_table(table_name.to_sym, :atomic_switch => true, :cleanup => true) do |t|
         t.add_column(:logins, "INT(12) DEFAULT '0'")
       end
 
@@ -42,42 +42,16 @@ describe Lhm do
       end
     end
 
-    it "should retain triggers while migration if retain_triggers is set to true in locked switch" do
-      table_name = 'users'
-      trigger_name = 'timestamp_trigger'
-      check_and_create_trigger_on_users_table
-      Lhm.change_table(table_name.to_sym, :atomic_switch => false, :cleanup => true, :retain_triggers => true) do |t|
-        t.add_column(:logins, "INT(12) DEFAULT '0'")
-      end
-
-      slave do
-        trigger_exists?(table_name, trigger_name).must_equal true
-      end
-    end
-
-    it "should not retain triggers while migration if retain_triggers is set to false" do
-      table_name = 'users'
-      trigger_name = 'timestamp_trigger'
-      check_and_create_trigger_on_users_table
-      Lhm.change_table(table_name.to_sym, :atomic_switch => false, :cleanup => true, :retain_triggers => false) do |t|
-        t.add_column(:logins_1, "INT(12) DEFAULT '0'")
-      end
-
-      slave do
-        trigger_exists?(table_name, trigger_name).must_equal false
-      end
-    end
-
-    it "should not retain triggers while migration if retain_triggers is not passed in the options" do
+    it "should retain triggers while migration in locked switch" do
       table_name = 'users'
       trigger_name = 'timestamp_trigger'
       check_and_create_trigger_on_users_table
       Lhm.change_table(table_name.to_sym, :atomic_switch => false, :cleanup => true) do |t|
-        t.add_column(:logins_2, "INT(12) DEFAULT '0'")
+        t.add_column(:logins, "INT(12) DEFAULT '0'")
       end
 
       slave do
-        trigger_exists?(table_name, trigger_name).must_equal false
+        trigger_exists?(table_name, trigger_name).must_equal true
       end
     end
 

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -13,6 +13,7 @@ describe Lhm do
   describe 'retain triggers' do
     before(:each) do
       slave do
+        Lhm.cleanup(:true)
         table_create(:users)
       end
     end


### PR DESCRIPTION
Currently as per the fix in [https://github.com/freshworks/large-hadron-migrator/pull/11](https://github.com/freshworks/large-hadron-migrator/pull/11/files) we retain triggers only if retain_triggers flag is set to true in migration script. This leads to issues when this flag is missed to be passed while running migration.
Due to this we have to update the logic to retain triggers by default, so we have to remove the retain_triggers check in the logic and preserve triggers by default.

Fix made:
Removed the retain_triggers flag check in the preserve trigger logic

Test case sheet:
https://docs.google.com/spreadsheets/d/1HVbSdx19YPhJ96L_e3cz4tErIJ-vdqMK6hKUobyLQaM/edit?usp=sharing