### PR TITLE
DB user fix for retain triggers

### DIFF
--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -39,7 +39,6 @@ module Lhm
       migration = @migrator.run
 
       retain_triggers = options.fetch(:retain_triggers, true)
-      puts "retain_triggers - #{retain_triggers}"
       Entangler.new(migration, @connection).run do
         Chunker.new(migration, @connection, options).run
         if options[:atomic_switch]

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -39,6 +39,7 @@ module Lhm
       migration = @migrator.run
 
       retain_triggers = options.fetch(:retain_triggers, true)
+      puts "retain_triggers - #{retain_triggers}"
       Entangler.new(migration, @connection).run do
         Chunker.new(migration, @connection, options).run
         if options[:atomic_switch]

--- a/lib/lhm/trigger_switcher.rb
+++ b/lib/lhm/trigger_switcher.rb
@@ -29,7 +29,7 @@ module Lhm
       trigger_definition = result && result.length > 2 ? result[2] : ''
 
       # Replace definer if LHM_CHANGE_TRIGGER_DEFINER environment variable is set
-      trigger_definition = update_trigger_definer(trigger_definition) if ENV['LHM_CHANGE_TRIGGER_DEFINER'] && !trigger_definition.empty?
+      trigger_definition = update_trigger_definer(trigger_definition) if ENV['LHM_TRIGGER_DEFINER'] && !trigger_definition.empty?
       trigger_definition
     end
 

--- a/lib/lhm/trigger_switcher.rb
+++ b/lib/lhm/trigger_switcher.rb
@@ -29,13 +29,11 @@ module Lhm
       trigger_definition = result && result.length > 2 ? result[2] : ''
 
       # Replace definer if LHM_CHANGE_TRIGGER_DEFINER environment variable is set
-      puts "ENV['LHM_CHANGE_TRIGGER_DEFINER'] - #{ENV['LHM_CHANGE_TRIGGER_DEFINER']}"
       trigger_definition = update_trigger_definer(trigger_definition) if ENV['LHM_CHANGE_TRIGGER_DEFINER'] && !trigger_definition.empty?
       trigger_definition
     end
 
     def update_trigger_definer(trigger_definition)
-      puts "update_trigger_definer called"
       definer_user = ENV['LHM_TRIGGER_DEFINER'] || DEFAULT_TRIGGER_DEFINER
       # Match DEFINER=`user`@`host` pattern and replace with specified definer user@localhost
       trigger_definition.gsub(/DEFINER=`[^`]+`@`[^`]+`/, "DEFINER=`#{definer_user}`@`localhost`")

--- a/lib/lhm/trigger_switcher.rb
+++ b/lib/lhm/trigger_switcher.rb
@@ -1,5 +1,7 @@
 module Lhm
   class TriggerSwitcher
+    DEFAULT_TRIGGER_DEFINER = 'migration'.freeze
+
     def copy_triggers(source_table, destination_table_name, connection)
       return unless !destination_table_name.empty? && connection.table_exists?(destination_table_name)
 
@@ -24,7 +26,19 @@ module Lhm
       result = connection.execute("SHOW CREATE TRIGGER #{trigger_name};").first
       # sample result => ["update_message_old_5", "NO_ENGINE_SUBSTITUTION", "CREATE DEFINER=`root`@`localhost` TRIGGER update_message_old_5 BEFORE INSERT ON `lhma_2023_09_04_14_32_54_810_logs_table` FOR EACH ROW\n BEGIN\n IF NEW.message = '1' THEN\n SET NEW.message = 'true';\n END IF;\n END", "utf8", "utf8_general_ci", "utf8_unicode_ci", 2023-09-04 14:32:43 UTC]
       # create trigger definition will be stored in the third index in the result, ideally result will always be of length 7 if its executed successfully.
-      result && result.length > 2 ? result[2] : ''
+      trigger_definition = result && result.length > 2 ? result[2] : ''
+
+      # Replace definer if LHM_CHANGE_TRIGGER_DEFINER environment variable is set
+      puts "ENV['LHM_CHANGE_TRIGGER_DEFINER'] - #{ENV['LHM_CHANGE_TRIGGER_DEFINER']}"
+      trigger_definition = update_trigger_definer(trigger_definition) if ENV['LHM_CHANGE_TRIGGER_DEFINER'] && !trigger_definition.empty?
+      trigger_definition
+    end
+
+    def update_trigger_definer(trigger_definition)
+      puts "update_trigger_definer called"
+      definer_user = ENV['LHM_TRIGGER_DEFINER'] || DEFAULT_TRIGGER_DEFINER
+      # Match DEFINER=`user`@`host` pattern and replace with specified definer user@localhost
+      trigger_definition.gsub(/DEFINER=`[^`]+`@`[^`]+`/, "DEFINER=`#{definer_user}`@`localhost`")
     end
 
     def remove_timestamp_from_trigger_name_if_exists(trigger_name)

--- a/lib/lhm/trigger_switcher.rb
+++ b/lib/lhm/trigger_switcher.rb
@@ -1,7 +1,5 @@
 module Lhm
   class TriggerSwitcher
-    DEFAULT_TRIGGER_DEFINER = 'migration'.freeze
-
     def copy_triggers(source_table, destination_table_name, connection)
       return unless !destination_table_name.empty? && connection.table_exists?(destination_table_name)
 
@@ -34,9 +32,8 @@ module Lhm
     end
 
     def update_trigger_definer(trigger_definition)
-      definer_user = ENV['LHM_TRIGGER_DEFINER'] || DEFAULT_TRIGGER_DEFINER
-      # Match DEFINER=`user`@`host` pattern and replace with specified definer user@localhost
-      trigger_definition.gsub(/DEFINER=`[^`]+`@`[^`]+`/, "DEFINER=`#{definer_user}`@`localhost`")
+      # Match DEFINER=`user`@ pattern and replace only the user part, keeping the original host
+      trigger_definition.gsub(/DEFINER=`[^`]+`@/, "DEFINER=`#{ENV['LHM_TRIGGER_DEFINER']}`@")
     end
 
     def remove_timestamp_from_trigger_name_if_exists(trigger_name)

--- a/lib/lhm/trigger_switcher.rb
+++ b/lib/lhm/trigger_switcher.rb
@@ -28,7 +28,7 @@ module Lhm
       # create trigger definition will be stored in the third index in the result, ideally result will always be of length 7 if its executed successfully.
       trigger_definition = result && result.length > 2 ? result[2] : ''
 
-      # Replace definer if LHM_CHANGE_TRIGGER_DEFINER environment variable is set
+      # Replace definer if LHM_TRIGGER_DEFINER environment variable is set
       trigger_definition = update_trigger_definer(trigger_definition) if ENV['LHM_TRIGGER_DEFINER'] && !trigger_definition.empty?
       trigger_definition
     end


### PR DESCRIPTION
Currently for retaining existing triggers in the db, the default db user is being selected.  Recently the privileges for the default user has been updates so that the privileges for creating triggers has been removed.  To fix this, this PR introduces changes to provide custom db user via ENV data.

`def update_trigger_definer(trigger_definition)
      definer_user = ENV['LHM_TRIGGER_DEFINER'] || DEFAULT_TRIGGER_DEFINER
      # Match DEFINER=`user`@`host` pattern and replace with specified definer user@localhost
      trigger_definition.gsub(/DEFINER=`[^`]+`@`[^`]+`/, "DEFINER=`#{definer_user}`@`localhost`")
 end`